### PR TITLE
Styling pt 01

### DIFF
--- a/app/reader/filters.py
+++ b/app/reader/filters.py
@@ -13,3 +13,15 @@ def display_date(dt):
     else:
         # return f"{dt.month} {dt.day}, {dt.year}"
         return dt.strftime("%d %B %Y")
+
+@reader_bp.app_template_filter('strip_p_tag')
+def strip_p_tags(paragraph):
+    if paragraph[0:3] == '<p>':
+        paragraph = paragraph[3:]
+    
+    if paragraph[-4:] == '</p>':
+        paragraph = paragraph[:-4]
+    
+    return paragraph
+
+# NEED: A filter that closes all tags in the order they were opened.

--- a/app/reader/reader_routes.py
+++ b/app/reader/reader_routes.py
@@ -8,13 +8,20 @@ from app import models
 def reader_home():
     try:
         posts_from_db = models.Article.get_all_articles()
+        other_posts_from_db = models.Article.get_random_articles(5)
+        print(other_posts_from_db[0])
         posts = []
+        other_posts = []
         for p in posts_from_db:
             post = {"post_id": p.id, "post_title": p.title, "post_subtitle": p.subtitle, "post_date": p.posted_date}
             print(type(p.posted_date))
             post["post_content"] = p.content_html
             posts.append(post)
-        return render_template("reader/home.html", posts=posts)
+        for op in other_posts_from_db:
+            p = {"post_id": op.id, "post_title": op.title}
+            print(p)
+            other_posts.append(p)
+        return render_template("reader/home.html", posts=posts, other_posts=other_posts)
     except exc.SQLAlchemyError:
         flash('Could not retrieve posts.', 'error')
         return render_template("reader/home.html", posts=[])
@@ -23,7 +30,12 @@ def reader_home():
 @reader_bp.route("/post/<int:post_id>")
 def read_post(post_id):
     post_from_db = models.Article.get_article(post_id)
-    other_posts = models.Article.get_random_articles(5)
+    other_posts_from_db = models.Article.get_random_articles(5)
     post = {"post_id": post_from_db.id, "post_title": post_from_db.title, "post_subtitle": post_from_db.subtitle,
             "post_date": post_from_db.posted_date, "post_content": post_from_db.content_html}
+    other_posts = []
+    for op in other_posts_from_db:
+        p = {"post_id": other_posts_from_db.id, "post_title": other_posts_from_db.title}
+        other_posts.append(p)
+    print(other_posts)
     return render_template("reader/reader_view_post.html", post=post, other_posts=other_posts)

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -1,0 +1,58 @@
+body {
+    box-sizing: border-box;
+}
+
+h1 {
+    font-size: 2.3em;
+}
+
+h2 {
+    font-size: 2em;
+}
+
+h3 {
+    font-size: 1.7em;
+}
+
+h4 {
+    font-size: 1.5em;
+}
+
+h5 {
+    font-size: 1.3em;
+}
+
+h6 {
+    font-size: 1.1em;
+}
+
+a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.h3 {
+    font-size: 1.7em;
+}
+
+.mt-2 {
+    margin-top: 1em;
+}
+
+.my-2 {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+.mx-2 {
+    margin-left: 1em;
+    margin-right: 1em;
+}
+
+.text-justified {
+    text-align: justify;
+}
+
+.text-right {
+    text-align: right;
+}

--- a/app/static/css/cosmetic.css
+++ b/app/static/css/cosmetic.css
@@ -1,0 +1,9 @@
+body {
+    background-color: #fcfcfc;
+    color: #383838;
+    font-family: "Work Sans", sans-serif;
+}
+
+.text-muted {
+    color: #6c757d;
+}

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -1,4 +1,4 @@
-@media screen and (min-width: 360px) {
+@media screen and (min-width: 1px) {
     body {
         display: grid;
         grid-template-columns: repeat(12, 1fr);
@@ -11,13 +11,11 @@
 
     #header {
         grid-area: h;
-        border: 2px solid green;
     }
 
     #left_gutter {
         grid-area: l;
         margin: 0;
-        border: 2px solid red;
     }
 
     #right_gutter {
@@ -28,7 +26,6 @@
         box-sizing: border-box;
         grid-area: c;
         padding: 2rem;
-        border: 2px solid blue;
     }
 }
 
@@ -44,13 +41,11 @@
 
     #header {
         grid-area: h;
-        border: 2px solid green;
     }
 
     #left_gutter {
         grid-area: l;
         margin: 3rem 0 3rem 3rem;
-        border: 2px solid red;
     }
 
     #right_gutter {
@@ -61,7 +56,6 @@
         box-sizing: border-box;
         grid-area: c;
         padding: 2rem;
-        border: 2px solid blue;
     }
 }
 
@@ -77,32 +71,22 @@
 
     #header {
         grid-area: h;
-        border: 2px solid green;
     }
 
     #left_gutter {
         grid-area: l;
         margin: 3rem 0 3rem 3rem;
-        border: 2px solid red;
     }
 
     #right_gutter {
         display: block;
         grid-area: r;
         margin: 3rem 3rem 3rem 0;
-        border: 2px solid red;
     }
 
     #content_container {
         box-sizing: border-box;
         grid-area: c;
         padding: 2rem;
-        border: 2px solid blue;
     }
-}
-
-.post_preview {
-    border: 3px solid cyan;
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
 }

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -1,0 +1,108 @@
+@media screen and (min-width: 360px) {
+    body {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        grid-template-rows: 100px minmax(auto, 1fr);
+        grid-template-areas:
+        "h h h h h h h h h h h h"
+        "c c c c c c c c c c c c"
+        "l l l l l l l l l l l l";
+    }
+
+    #header {
+        grid-area: h;
+        border: 2px solid green;
+    }
+
+    #left_gutter {
+        grid-area: l;
+        margin: 0;
+        border: 2px solid red;
+    }
+
+    #right_gutter {
+        display: none;
+    }
+
+    #content_container {
+        box-sizing: border-box;
+        grid-area: c;
+        padding: 2rem;
+        border: 2px solid blue;
+    }
+}
+
+@media screen and (min-width: 768px) {
+    body {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        grid-template-rows: 100px minmax(auto, 1fr);
+        grid-template-areas:
+        "h h h h h h h h h h h h"
+        "l l l l c c c c c c c c";
+    }
+
+    #header {
+        grid-area: h;
+        border: 2px solid green;
+    }
+
+    #left_gutter {
+        grid-area: l;
+        margin: 3rem 0 3rem 3rem;
+        border: 2px solid red;
+    }
+
+    #right_gutter {
+        display: none;
+    }
+
+    #content_container {
+        box-sizing: border-box;
+        grid-area: c;
+        padding: 2rem;
+        border: 2px solid blue;
+    }
+}
+
+@media screen and (min-width: 1366px) {
+    body {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        grid-template-rows: 100px minmax(auto, 1fr);
+        grid-template-areas:
+        "h h h h h h h h h h h h"
+        "l l l c c c c c c r r r";
+    }
+
+    #header {
+        grid-area: h;
+        border: 2px solid green;
+    }
+
+    #left_gutter {
+        grid-area: l;
+        margin: 3rem 0 3rem 3rem;
+        border: 2px solid red;
+    }
+
+    #right_gutter {
+        display: block;
+        grid-area: r;
+        margin: 3rem 3rem 3rem 0;
+        border: 2px solid red;
+    }
+
+    #content_container {
+        box-sizing: border-box;
+        grid-area: c;
+        padding: 2rem;
+        border: 2px solid blue;
+    }
+}
+
+.post_preview {
+    border: 3px solid cyan;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,89 +1,10 @@
-/* RESET */
-/* Courtesy Alligator.io (https://alligator.io/css/minimal-css-reset/) */
-html {
-    box-sizing: border-box;
-    font-size: 16px;
-}
-
-*, *:before, *:after {
-    box-sizing: inherit;
-}
-
-body, h1, h2, h3, h4, h5, h6, p, ol, ul {
-    margin: 0;
-    padding: 0;
-    font-weight: normal;
-}
-
-ol, ul {
-    list-style: none;
-}
-
-img {
-    max-width: 100%;
-    height: auto;
-}
-
-/* LAYOUT */
-body {
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    grid-template-rows: 100px minmax(auto, 1fr);
-    grid-template-areas:
-    "h h h h h h h h h h h h"
-    "l l l c c c c c c c c c";
-}
-
-#header {
-    grid-area: h;
-}
-
-#left_nav {
-    grid-area: l;
-    margin: 3rem 0 3rem 3rem;
-}
-
-#content_container {
-    box-sizing: border-box;
-    grid-area: c;
-    padding: 3rem;
-}
-
 /* GENERAL STYLES */
-body {
-    background-color: #fcfcfc;
-    font-family: "Work Sans", sans-serif;
-    box-sizing: border-box;
-}
 
-h1 {
-    font-size: 2.3em;
-}
-
-h2 {
-    font-size: 2em;
-}
-
-h3 {
-    font-size: 1.7em;
-}
-
-h4 {
-    font-size: 1.5em;
-}
-
-h5 {
-    font-size: 1.3em;
-}
-
-h6 {
-    font-size: 1.1em;
-}
 
 /* HEADER */
 #header_container {
     align-items: center;
-    background-color: #fcfcfc;
+    /*background-color: #fcfcfc;*/
     border-bottom: 1px solid #24242344;
     color: #242423;
     display: flex;

--- a/app/static/css/reset.css
+++ b/app/static/css/reset.css
@@ -1,0 +1,25 @@
+/* RESET */
+/* Courtesy Alligator.io (https://alligator.io/css/minimal-css-reset/) */
+html {
+    box-sizing: border-box;
+    font-size: 16px;
+}
+
+*, *:before, *:after {
+    box-sizing: inherit;
+}
+
+body, h1, h2, h3, h4, h5, h6, p, ol, ul {
+    margin: 0;
+    padding: 0;
+    font-weight: normal;
+}
+
+ol, ul {
+    list-style: none;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}

--- a/app/templates/reader/home.html
+++ b/app/templates/reader/home.html
@@ -1,4 +1,4 @@
-{% extends "shared/home_template.html" %}
+{% extends "shared/foundation_centered.html" %}
 {% import "shared/macros.html" as macros %}
 
 {% block content %}

--- a/app/templates/reader/home.html
+++ b/app/templates/reader/home.html
@@ -1,6 +1,12 @@
 {% extends "shared/foundation_centered.html" %}
 {% import "shared/macros.html" as macros %}
 
+{% block left_gutter %}
+    {% with other_posts=other_posts %}
+        {% include "reader/posts_list.html" %}
+    {% endwith %}
+{% endblock %}
+
 {% block content %}
     {% if posts %}
         {% for p in posts %}

--- a/app/templates/reader/posts_list.html
+++ b/app/templates/reader/posts_list.html
@@ -1,5 +1,34 @@
+<style>
+    .other-posts h3 {
+        margin-bottom: 1rem;
+    }
+
+    .other-post {
+        border-left: 1px solid #5e5e5e;
+        height: 30px;
+        padding-left: 1rem;
+        display: flex;
+        align-items: center;
+        margin-bottom: 1rem;
+    }
+
+    .other-post:hover {
+        font-weight: bold;
+        border-left: 2px solid #383838;
+    }
+
+    .other-post a {
+    }    
+</style>
+
+<div class="other-posts">
 <h3>Other Posts:</h3>
 
+{% if other_posts and other_posts|length > 0 %}
 {% for p in other_posts %}
-    <p><a href="{{ url_for('reader_bp.read_post', post_id=p.id) }}">{{ p.title|truncate(60, False, "...") }}</a></p>
+    <p class="other-post"><a href="{{ url_for('reader_bp.read_post', post_id=p.post_id) }}">{{ p.post_title|truncate(60, False, "...") }}</a></p>
 {% endfor %}
+{% else %}
+    <p>No other posts...</p>
+{% endif %}
+</div>

--- a/app/templates/reader/reader_view_post.html
+++ b/app/templates/reader/reader_view_post.html
@@ -1,6 +1,6 @@
 {% extends "shared/post_template.html" %}
 
-{% block left_nav %}
+{% block left_gutter %}
     {% with other_posts=other_posts %}
         {% include "reader/posts_list.html" %}
     {% endwith %}

--- a/app/templates/shared/foundation_centered.html
+++ b/app/templates/shared/foundation_centered.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>random.choice(articles)</title>
+    <!--{{ url_for('static', filename='css/main.css') }}-->
+
+    <link href="{{ url_for('static', filename='css/reset.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/layout.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/base.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/cosmetic.css') }}" rel="stylesheet">
+
+<link href="https://fonts.googleapis.com/css2?family=Itim&display=swap" rel="stylesheet">
+<body>
+
+    <div id="header">
+        {% block header %}
+            {% include "shared/header.html" %}
+        {% endblock %}
+    </div>
+
+    <div id="left_gutter">        
+        {% block left_gutter %}
+        {% endblock %}
+    </div>
+
+    <div id="content_container">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% for category, message in messages %}
+                <span>[{{ category }}] {{ message }}</span>
+            {% endfor %}
+        {% endwith %}
+        {% block content %}
+        {% endblock %}
+    </div>
+
+    <div id="right_gutter">
+        {% block right_gutter %}
+        {% endblock %}
+    </div>
+    
+</body>
+</html>

--- a/app/templates/shared/header.html
+++ b/app/templates/shared/header.html
@@ -1,3 +1,25 @@
-<div id="header_container">
+<style>
+    .header-container {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-bottom: 1px solid #383838;
+    }
+
+    .header-container a {
+        min-width: 450px;
+        width: 100%;
+        display: flex;
+        align-items: center;
+    }
+
+    .header-container a img {
+        margin: auto;
+    }
+</style>
+
+<div class="header-container">
     <a href="/"><img src="{{url_for('static', filename='images/logo.png')}}" /></a>
 </div>

--- a/app/templates/shared/macros.html
+++ b/app/templates/shared/macros.html
@@ -4,11 +4,16 @@
             margin-bottom: 2rem;
             position: relative;
             display: flex;
-            flex-direction: column;            
+            flex-direction: column; 
+            padding: 1rem;
         }
 
-        .post:hover .post-header {
-            border-left: 2px solid #383838;
+        .post:hover {
+            transform: scale(1.015);
+        }
+
+        .post:hover .post-header::before {
+            outline: 2px solid #383838;            
         }
 
         .post:hover .post-preview::before {
@@ -24,8 +29,21 @@
         .post-header {
             display: block;
             margin-bottom: 1rem;
-            border-left: 1px solid #5e5e5e;
+            /* border-left: 2px solid #5e5e5e; */
             padding-left: 1rem;
+            box-sizing: border-box;
+            position: relative;
+        }
+
+        .post-header::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            background: red;
+            width: 0px;
+            outline: 1px solid #383838;
         }
 
         .post-preview {
@@ -47,12 +65,40 @@
         }
 
         .post-footer {
-            display: block;
+            display: flex;
+            justify-content: right;
             background: inherit;
-            padding-top: 1rem;
             padding-bottom: 1rem;
-            padding-left: 1rem;
+            position: relative;
+            height: 4rem;
+            color: inherit;
         }
+
+        .post-footer span {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            padding: .6rem;
+            vertical-align: middle;
+            /*background: #383838;
+            color: #fcfcfc;*/
+            color: #383838;
+            z-index: 1;
+        }
+
+        /*.post-footer span::before {
+            content: '';
+            background: transparent;
+            width: 60%;
+            position: absolute;
+            top: -6px;
+            right: -6px;
+            bottom: -6px;
+            border-bottom: 2px solid #383838;
+            border-right: 2px solid #383838;
+            border-top: 2px solid #383838;
+            z-index: 0;
+        }*/
     </style>
     <div class="post">
         <a href="{{ url_for('reader_bp.read_post', post_id=post_id) }}">
@@ -64,7 +110,7 @@
                 {{ post_content|safe }}
             </div>
             <div class="post-footer">
-                <p class="mt-2 text-right">{{ post_date|display_date()|safe }}</p>
+                <span><em>{{ post_date|display_date()|safe }}</em></span>
             </div>
         </a>
     </div>

--- a/app/templates/shared/macros.html
+++ b/app/templates/shared/macros.html
@@ -1,11 +1,71 @@
 {% macro post_preview(post_id, post_title, post_subtitle, post_date, post_content) %}
-    <div class="post_preview">
+    <style>
+        .post {
+            margin-bottom: 2rem;
+            position: relative;
+            display: flex;
+            flex-direction: column;            
+        }
+
+        .post:hover .post-header {
+            border-left: 2px solid #383838;
+        }
+
+        .post:hover .post-preview::before {
+            content: '';
+            height: 100%;
+            width: 100%;
+            top: 0;
+            left: 0;
+            background: linear-gradient(transparent 60%, #fcfcfc);
+            position: absolute;
+        }
+
+        .post-header {
+            display: block;
+            margin-bottom: 1rem;
+            border-left: 1px solid #5e5e5e;
+            padding-left: 1rem;
+        }
+
+        .post-preview {
+            height: 10rem;
+            display: block;
+            overflow: hidden;
+            position: relative;
+            padding-left: 1rem;
+        }
+
+        .post-preview::before {
+            content: '';
+            height: 100%;
+            width: 100%;
+            top: 0;
+            left: 0;
+            background: linear-gradient(transparent 40%, #fcfcfc);
+            position: absolute;
+        }
+
+        .post-footer {
+            display: block;
+            background: inherit;
+            padding-top: 1rem;
+            padding-bottom: 1rem;
+            padding-left: 1rem;
+        }
+    </style>
+    <div class="post">
         <a href="{{ url_for('reader_bp.read_post', post_id=post_id) }}">
-            <h1>{{ post_title|safe }}</h1>
-            <h2 class="text-muted h3">{{ post_subtitle|safe }}</h2>
-            
-            <p class="mt-2 text-justified">{{ post_content|truncate(200, True, "...", 3)|strip_p_tag }}</p>
-            <p class="mt-2 text-right">{{ post_date|display_date()|safe }}</p>
+            <div class="post-header">
+                <h1 class>{{ post_title|safe }}</h1>
+                <h2 class="text-muted h3">{{ post_subtitle|safe }}</h2>
+            </div>
+            <div class="post-preview">
+                {{ post_content|safe }}
+            </div>
+            <div class="post-footer">
+                <p class="mt-2 text-right">{{ post_date|display_date()|safe }}</p>
+            </div>
         </a>
     </div>
 {% endmacro %}

--- a/app/templates/shared/macros.html
+++ b/app/templates/shared/macros.html
@@ -1,9 +1,12 @@
 {% macro post_preview(post_id, post_title, post_subtitle, post_date, post_content) %}
     <div class="post_preview">
-        <h3><a href="{{ url_for('reader_bp.read_post', post_id=post_id) }}">{{ post_title|safe }}</a></h3>
-        <p>{{ post_subtitle|safe }}</p>
-        <p>{{ post_date|display_date()|safe }}</p>
-        <p>{{ post_content|truncate(500, True, "...", 3)|safe }}</p>
+        <a href="{{ url_for('reader_bp.read_post', post_id=post_id) }}">
+            <h1>{{ post_title|safe }}</h1>
+            <h2 class="text-muted h3">{{ post_subtitle|safe }}</h2>
+            
+            <p class="mt-2 text-justified">{{ post_content|truncate(200, True, "...", 3)|strip_p_tag }}</p>
+            <p class="mt-2 text-right">{{ post_date|display_date()|safe }}</p>
+        </a>
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
Reader home page styling:

- Updated post preview so goofy stuff doesn't have to be done to render it to the screen
- Added some styling to each preview with hover effects (needs more work but it's on its way)
- Made styles of some items more modular by placing them within the templates
- Updated the header template styling to center the logo
- Styled the "Other Posts" section 
- Updated reader routes to properly handle articles from the DB for display (previously, article objects were not handled correctly for the "Other Articles" section display)
