### PR TITLE
Created Component for Flask Flashed Messages

### DIFF
--- a/app/templates/shared/foundation_centered.html
+++ b/app/templates/shared/foundation_centered.html
@@ -19,6 +19,8 @@
         {% block header %}
             {% include "shared/header.html" %}
         {% endblock %}
+
+        {% include "shared/messages.html" %}
     </div>
 
     <div id="left_gutter">        
@@ -27,11 +29,6 @@
     </div>
 
     <div id="content_container">
-        {% with messages = get_flashed_messages(with_categories=true) %}
-            {% for category, message in messages %}
-                <span>[{{ category }}] {{ message }}</span>
-            {% endfor %}
-        {% endwith %}
         {% block content %}
         {% endblock %}
     </div>

--- a/app/templates/shared/foundation_content_only.html
+++ b/app/templates/shared/foundation_content_only.html
@@ -19,14 +19,11 @@
         {% block header %}
             {% include "shared/header.html" %}
         {% endblock %}
+
+        {% include "shared/messages.html" %}
     </div>
 
-    <div id="content_container">
-        {% with messages = get_flashed_messages(with_categories=true) %}
-            {% for category, message in messages %}
-                <span>[{{ category }}] {{ message }}</span>
-            {% endfor %}
-        {% endwith %}
+    <div id="content_container">        
         {% block content %}
         {% endblock %}
     </div>

--- a/app/templates/shared/messages.html
+++ b/app/templates/shared/messages.html
@@ -1,0 +1,133 @@
+<style>
+    .messages {
+        width: 50%;
+        margin: auto;
+        display: block;
+        padding-top: 1rem;
+        z-index: 1000;
+        position: relative;
+    }
+
+    .message-container {
+        min-height: 3rem;
+        padding: .5rem 3rem .5rem 3rem;
+        border: 1px solid #383838;
+        background: #fcfcfc;
+        width: 100%;
+        margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        position: relative;
+    }
+
+    .message-container:hover {
+        transform: scale(1.02);
+    }
+
+    .message-container:hover .close {
+        font-weight: bold;
+    }
+
+    .message {
+        position: relative;
+        width: 100%;
+        height: 100%;
+    }
+
+    .symbol {
+        margin-left: 0;
+        font-size: 1.3em;
+        font-weight: bold;
+        position: absolute;
+        left: .5rem;
+        top: 0;
+        bottom: 0;
+        margin: auto;
+        height: 2rem;
+        width: 2rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .message .text {
+        text-align: center;
+    }
+
+    .close {
+        position: absolute;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        margin-right: 1rem;
+    }
+
+    .close::before {
+        content: 'X';
+    }
+
+    /* TODO: JS to remove the messages. */
+
+    .message-category-message {}
+
+    .message-category-message .symbol {
+        background: #383838;
+        color: #fcfcfc;
+    }
+
+    .message-category-error {
+        border: 1px solid #de362a;
+    }
+
+    .message-category-error .symbol {
+        background: #de362a;
+        color: #fcfcfc;
+    }
+
+    .message-category-info {
+        border: 1px solid #569de8;
+    }
+
+    .message-category-info .symbol {
+        background: #569de8;
+        color: #fcfcfc;
+    }
+
+    .message-category-warning {
+        border: 1px solid #e87548;
+    }
+
+    .message-category-warning .symbol {
+        background: #e87548;
+        color: #fcfcfc;
+    }
+</style>
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div class="messages">
+            {% for category, message in messages %}
+                <div class="message-container message-category-{{ category }}" id="message-{{ loop.index }}">
+                    <div class="symbol">!</div>
+                    <div class="message">                        
+                        <div class="text">{{ message }}</div>
+                    </div>
+                    <span class="close" onclick="RemoveMessage('message-{{ loop.index }}')"></span>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}
+
+<script>
+    let RemoveMessage = function(messageId) {
+        console.log('remove.');
+        document.getElementById(messageId).remove();
+    };
+</script>


### PR DESCRIPTION
Flask has a system for sending messages to the UI called Flashed Messages. Information can be found [here](https://flask.palletsprojects.com/en/1.1.x/patterns/flashing/). To add a flashed message, the code (in a route or somewhere) would look like this:

`flash('message', 'category')`

Where `message` is the content to display on the UI and `category` is an arbitrary name for the category of the message, typically warning, alert, informational, etc.

A component in `templates/shared/messages.html` was created that handles the display of any items in the list of flashed messages (this list is maintained by Flask; it is cleared between requests). The component will handle the display of messages on the UI, categorize them with a color for each level (message, error, info, warning), and create functionality that allows the user to remove them from the interface. This template was added to each base template in use. 